### PR TITLE
Use ENV instead of deprecated `set-output`

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Mdformat
         uses: ydah/mdformat-action@main
         with:

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -36,7 +36,7 @@ run_mdformat() {
     echo "### Linting successful! :rocket:" >>$GITHUB_STEP_SUMMARY
     echo "${lint_output}"
     echo
-    echo ::set-output name=mdformat_output::"${lint_output}"
+    echo "{mdformat_output}=${lint_output}" >>$GITHUB_OUTPUT
     exit ${lint_exit_code}
   fi
 
@@ -63,7 +63,7 @@ run_mdformat() {
     lint_exit_code=0
   fi
 
-  echo ::set-output name=mdformat_output::"${lint_output}"
+  echo "{mdformat_output}=${lint_output}" >>$GITHUB_OUTPUT
   exit ${lint_exit_code}
 }
 


### PR DESCRIPTION
The deprecation is documented at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
