### PR TITLE
Bump Python version from 3.10 to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bullseye
+FROM python:3.13-bullseye
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN pip install --upgrade pip


### PR DESCRIPTION
mdformat supports an `exclude` option in `.mdformat.toml`, which I was trying to use to omit my `docs/` directory. However, it was failing with the following error:
```
lint: info: mdformat on ..
Error: 'exclude' patterns are only available on Python 3.13+.
Please remove the 'exclude' list from your .mdformat.toml or upgrade Python
version.
```

This pull request bumps the Python version mdformat-action uses to 3.13 to fix the above.